### PR TITLE
Prevent webpack from resolving symlinks

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -7,4 +7,9 @@ module.exports = {
       patterns: [path.resolve(__dirname, './src/styles/globals.scss')],
     },
   },
+  configureWebpack: {
+    resolve: {
+      symlinks: false
+    },
+  }
 };


### PR DESCRIPTION
Resolves the infinite loop we saw when trying to work with `scaife-widgets` locally via `yarn link`.

Instructions for developing scaife-widgets in parallel can be found at:
https://github.com/scaife-viewer/scaife-widgets/blob/improve-dev-workflow/README.md#develop-scaife-widgets-in-parallel-with-a-scaife-viewer-front-end