### PR TITLE
New Alexandria, Word List Widgets

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#508b48f9aaad6c452916b295d8e87de49d5f9915",
+    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#c16bdb4e6d9a9a8e28eddab2d19de3e1eac73cf1",
     "apollo-boost": "^0.4.7",
     "core-js": "^3.5.0",
     "graphql": "^14.4.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.26",
     "@fortawesome/free-solid-svg-icons": "^5.12.0",
     "@fortawesome/vue-fontawesome": "^0.1.9",
-    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#a1313b1f4eb995790fc0c0aa8da193591878da95",
+    "@scaife-viewer/scaife-widgets": "git://github.com/scaife-viewer/scaife-widgets#508b48f9aaad6c452916b295d8e87de49d5f9915",
     "apollo-boost": "^0.4.7",
     "core-js": "^3.5.0",
     "graphql": "^14.4.2",

--- a/src/reader/components/ReaderView.vue
+++ b/src/reader/components/ReaderView.vue
@@ -10,12 +10,14 @@
   import {
     LibraryWidget,
     MetadataWidget,
+    NewAlexandriaWidget,
     PassageAncestorsWidget,
     PassageChildrenWidget,
     PassageReferenceWidget,
     TextSizeWidget,
     TextWidthWidget,
     TOCWidget,
+    WordListWidget,
   } from '@scaife-viewer/scaife-widgets';
   import ReaderWidget from '@/reader/widgets/ReaderWidget.vue';
   import { FETCH_METADATA, FETCH_LIBRARY } from '@/constants';
@@ -40,7 +42,13 @@
         ];
       },
       rightWidgets() {
-        return [MetadataWidget, TextSizeWidget, TextWidthWidget];
+        return [
+          MetadataWidget,
+          TextSizeWidget,
+          TextWidthWidget,
+          WordListWidget,
+          NewAlexandriaWidget,
+        ];
       },
     },
   };

--- a/src/reader/tests/ReaderWidget.spec.js
+++ b/src/reader/tests/ReaderWidget.spec.js
@@ -55,16 +55,16 @@ describe('ReaderWidget.vue', () => {
     });
     const paginators = wrapper.findAll(Paginator);
 
-    expect(paginators.at(0).props()).toStrictEqual({
+    expect(paginators.at(0).props()).toEqual({
       urn: new URN('urn:cts:greekLit:tlg0012.tlg001.msA:1.1-2'),
       direction: 'left',
     });
-    expect(wrapper.find(Reader).props()).toStrictEqual({
+    expect(wrapper.find(Reader).props()).toEqual({
       lines: ['some', 'data'],
       textSize: 'md',
       textWidth: 'normal',
     });
-    expect(paginators.at(1).props()).toStrictEqual({
+    expect(paginators.at(1).props()).toEqual({
       urn: new URN('urn:cts:greekLit:tlg0012.tlg001.msA:1.5-6'),
       direction: 'right',
     });


### PR DESCRIPTION
## Tickets
- [#33](https://trello.com/c/pO2JBrp7/33-backport-widget-word-list-from-scaife-viewer-to-scaife-widgets)
- [#44](https://trello.com/c/babCZfoz/34-backport-widget-new-alexandria-from-scaife-viewer-to-scaife-widgets)

## Features
- Add the New Alexandria Commentary and Word List widgets to the app.

<img width="2672" alt="Screenshot 2020-02-20 20 46 19" src="https://user-images.githubusercontent.com/1431010/74972479-0eac1000-5422-11ea-89a8-e5d9d8f20611.png">

## Related PR
- https://github.com/scaife-viewer/scaife-widgets/pull/19